### PR TITLE
Switch to serializable object.

### DIFF
--- a/lib/src/navigation/image_page.dart
+++ b/lib/src/navigation/image_page.dart
@@ -56,30 +56,31 @@ class _ImageScreenState extends State<ImageScreen> {
   /// to the port of Dawnn server. Currently used for testing.
   void _sendHTTPRequest(BuildContext context) async {
     // This is kind of a long method...
-    var body = Data(await _compressToBase64(File(imagePath)),
-            await _getId(context), await _getLocation())
-        .toJson();
+    var data = Data(await _compressToBase64(File(imagePath)),
+        await _getId(context), await _getLocation());
+    var body = json.encode(data.toJson());
 
     http.Response response;
     try {
-      response = await _client
-          .post(
-              Uri(
-                scheme: 'http',
-                userInfo: '',
-                host: '10.0.2.2',
-                port: 2423,
-                path: '/api/v1/image/',
-              ),
-              body: body)
-          .timeout(Duration(seconds: 10));
+      response = await _client.post(
+          Uri(
+            scheme: 'http',
+            userInfo: '',
+            host: '10.0.2.2',
+            port: 2423,
+            path: '/api/v1/image/',
+          ),
+          body: body,
+          headers: {
+            'Content-type': 'application/json'
+          }).timeout(Duration(seconds: 10));
     } catch (e) {
       // Probably timed out.
       print(e);
       showTopSnackBar(
           context,
           CustomSnackBar.error(
-              message: 'Post failed: request timed out. No internet?'));
+              message: 'Post failed. No internet?'));
       return;
     }
 

--- a/lib/src/network/data.dart
+++ b/lib/src/network/data.dart
@@ -1,0 +1,17 @@
+import 'package:dawnn_client/src/network/location.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'data.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class Data {
+  Data(this.base64image, this.hwid, this.location);
+
+  String base64image;
+  String hwid;
+  Location location;
+
+  factory Data.fromMap(Map<String, dynamic> json) => _$DataFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DataToJson(this);
+}

--- a/lib/src/network/data.dart
+++ b/lib/src/network/data.dart
@@ -5,9 +5,9 @@ part 'data.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class Data {
-  Data(this.base64image, this.hwid, this.location);
+  Data(this.image, this.hwid, this.location);
 
-  String base64image;
+  String image;
   String hwid;
   Location location;
 

--- a/lib/src/network/data.g.dart
+++ b/lib/src/network/data.g.dart
@@ -17,7 +17,7 @@ Data _$DataFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$DataToJson(Data instance) => <String, dynamic>{
-      'base64image': instance.base64image,
+      'base64image': instance.image,
       'hwid': instance.hwid,
       'location': instance.location?.toJson(),
     };

--- a/lib/src/network/data.g.dart
+++ b/lib/src/network/data.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Data _$DataFromJson(Map<String, dynamic> json) {
+  return Data(
+    json['base64image'] as String,
+    json['hwid'] as String,
+    json['location'] == null
+        ? null
+        : Location.fromJson(json['location'] as Map<String, dynamic>),
+  );
+}
+
+Map<String, dynamic> _$DataToJson(Data instance) => <String, dynamic>{
+      'base64image': instance.base64image,
+      'hwid': instance.hwid,
+      'location': instance.location?.toJson(),
+    };

--- a/lib/src/network/location.dart
+++ b/lib/src/network/location.dart
@@ -1,0 +1,16 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'location.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class Location {
+  double latitude;
+  double longitude;
+
+  Location(this.latitude, this.longitude);
+
+  factory Location.fromJson(Map<String, dynamic> json) =>
+      _$LocationFromJson(json);
+
+  Map<String, dynamic> toJson() => _$LocationToJson(this);
+}

--- a/lib/src/network/location.g.dart
+++ b/lib/src/network/location.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'location.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Location _$LocationFromJson(Map<String, dynamic> json) {
+  return Location(
+    (json['latitude'] as num)?.toDouble(),
+    (json['longitude'] as num)?.toDouble(),
+  );
+}
+
+Map<String, dynamic> _$LocationToJson(Location instance) => <String, dynamic>{
+      'latitude': instance.latitude,
+      'longitude': instance.longitude,
+    };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  json_annotation: ^4.0.0
+  json_annotation: ^3.1.1
   location: ^4.1.1
   convex_bottom_bar: ^3.0.0
   device_info: ^2.0.0
@@ -45,7 +45,7 @@ dev_dependencies:
   pedantic: ^1.9.0
   build_runner: ^1.10.0
   google_maps_flutter: ^2.0.1
-  json_serializable: ^4.0.2
+  json_serializable: ^3.5.1
   flutter_launcher_icons: ^0.9.0
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Switching to an object that we can serialize into JSON is better than writing a raw JSON, because it's cleaner and removes room for bugs.